### PR TITLE
fix: allow navigation from project cards when wallet disconnected 

### DIFF
--- a/src/app/explorePools/page.tsx
+++ b/src/app/explorePools/page.tsx
@@ -546,17 +546,18 @@ function ExploreFatePoolsClient() {
   }, [isConnected, router, walletClient, isConnectedChainSupported]);
 
   const handleUsePool = useCallback((poolId: string): void => {
-    if (!isConnected) { 
-      toast.error("Please connect your wallet to use this pool."); 
-      return; 
-    }
-    
     // Validate address format before proceeding
     if (!isAddress(poolId)) {
       toast.error("Invalid pool address format. Please try again.");
       return;
     }
-    
+
+    // If the user is not connected, show an informational toast
+    // but still allow navigation to the pool detail page.
+    if (!isConnected) {
+      toast.info("You are not connected. Connect your wallet to interact with this pool.");
+    }
+
     router.push(`/pool?id=${poolId}`);
   }, [isConnected, router]);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disconnected users can now access pool detail pages with an informational notification instead of being blocked from navigation. Pool address validation remains in place.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->