### PR TITLE
feat: Make footer copyright year dynamic

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -111,6 +111,7 @@ interface FooterProps {
 }
 
 export default function Footer({ className = "", onKYAClick }: FooterProps) {
+  const year = new Date().getFullYear();
   return (
     <footer className={`w-full rounded-lg backdrop-blur-md bg-white/10 dark:bg-black shadow-lg border border-white/10 dark:border-black/10 ${className}`}>
       <div className="px-4 sm:px-8  py-6 space-y-6">
@@ -207,7 +208,7 @@ export default function Footer({ className = "", onKYAClick }: FooterProps) {
 
         {/* Copyright Statement */}
         <div className="text-center text-sm text-gray-500 dark:text-gray-300 pt-4 border-t border-white/10 dark:border-black/10">
-          <p>© 2025 The Stable Order</p>
+          <p>© {year} The Stable Order</p>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
- Replace hardcoded 2025 year with dynamic new Date().getFullYear()
- Footer automatically updates to current year without manual maintenance
- Prevents outdated copyright information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* The footer copyright year now automatically reflects the current year instead of displaying a static value.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->